### PR TITLE
feat: add ND index trend component and screen

### DIFF
--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -1,0 +1,19 @@
+# Implementation Plan: ND index trend screen
+
+## Summary
+
+- Build a reusable React Native component to render the trend of an index on one exchange.
+- Assemble a screen that displays ND index trends for three major exchanges using the component.
+- Use mock data for now; API integration will come later.
+
+## Steps
+
+1. Create `src/components/NDIndexTrend.tsx` exporting a component that shows index name, exchange, value and percentage change with basic styling.
+2. Create `src/screens/NDIndexTrendScreen.tsx` rendering three `NDIndexTrend` components for Nikkei 225, Dow Jones and Nasdaq Composite using placeholder values.
+3. Format code with Prettier.
+4. Attempt to run lint and test commands.
+
+## Testing
+
+- `npx prettier . --check`
+- `npm test` (expected to show no tests yet)

--- a/src/components/NDIndexTrend.tsx
+++ b/src/components/NDIndexTrend.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+
+export type IndexTrend = {
+  name: string;
+  exchange: string;
+  value: number;
+  change: number; // percentage change
+};
+
+type Props = {
+  data: IndexTrend;
+};
+
+const NDIndexTrend: React.FC<Props> = ({ data }) => {
+  const changeColor = data.change >= 0 ? "#16a34a" : "#f43f5e";
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.titleRow}>
+        <Text style={styles.name}>{data.name}</Text>
+        <Text style={styles.exchange}>{data.exchange}</Text>
+      </View>
+      <View style={styles.valueRow}>
+        <Text style={styles.value}>{data.value.toFixed(2)}</Text>
+        <Text style={[styles.change, { color: changeColor }]}>
+          {data.change >= 0 ? "+" : ""}
+          {data.change.toFixed(2)}%
+        </Text>
+      </View>
+    </View>
+  );
+};
+
+export default NDIndexTrend;
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    borderBottomColor: "#eee",
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  titleRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  valueRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginTop: 4,
+  },
+  name: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  exchange: {
+    fontSize: 12,
+    color: "#666",
+  },
+  value: {
+    fontSize: 16,
+  },
+  change: {
+    fontSize: 16,
+  },
+});

--- a/src/screens/NDIndexTrendScreen.tsx
+++ b/src/screens/NDIndexTrendScreen.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { ScrollView } from "react-native";
+import NDIndexTrend, { IndexTrend } from "../components/NDIndexTrend";
+
+const sampleData: IndexTrend[] = [
+  { name: "Nikkei 225", exchange: "Tokyo", value: 32000, change: 0.5 },
+  { name: "Dow Jones", exchange: "NYSE", value: 34000, change: -0.3 },
+  { name: "Nasdaq Composite", exchange: "NASDAQ", value: 13000, change: 1.2 },
+];
+
+const NDIndexTrendScreen: React.FC = () => {
+  return (
+    <ScrollView>
+      {sampleData.map((idx) => (
+        <NDIndexTrend key={idx.name} data={idx} />
+      ))}
+    </ScrollView>
+  );
+};
+
+export default NDIndexTrendScreen;


### PR DESCRIPTION
## Summary
- add implementation plan for ND index trend screen
- create NDIndexTrend component and screen showing three exchanges

## Testing
- `npx --yes prettier implementation_plan.md src/components/NDIndexTrend.tsx src/screens/NDIndexTrendScreen.tsx --check`
- `npx eslint .` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c0850e80832abbfb578fc68a04fc