### PR TITLE
Add Capability Showcase card and analysis util with tests

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -20,6 +20,7 @@ import EventSheet from './src/EventSheet';
 import LiveTile from './src/LiveTile';
 import NotificationLine from './src/NotificationLine';
 import SettingsBlock from './src/SettingsBlock';
+import CapabilityShowcaseCard from './src/components/CapabilityShowcaseCard';
 import { useAppInit } from './src/hooks/useAppInit';
 import { useAppDispatch, useAppSelector } from './src/hooks/useRedux';
 import store from './src/store';
@@ -142,7 +143,7 @@ function HomeScreen() {
 
     // Apply sorting
     if (sortBy === 'importance') {
-      const importanceOrder = { '強': 3, '中': 2, '弱': 1 };
+      const importanceOrder = { 強: 3, 中: 2, 弱: 1 };
       filtered = [...filtered].sort((a, b) => {
         const aValue = importanceOrder[a.personalImpact] || 0;
         const bValue = importanceOrder[b.personalImpact] || 0;
@@ -208,6 +209,11 @@ function HomeScreen() {
               <Text style={styles.headerSubtitle}>リアルタイムIR通知</Text>
             </View>
           </TouchableOpacity>
+
+          <CapabilityShowcaseCard
+            events={filteredEvents}
+            notifications={filteredNotifications}
+          />
 
           {/* Search Bar */}
           {(allEvents.length > 0 || notifications.length > 0) && (

--- a/__tests__/capabilityShowcase.test.ts
+++ b/__tests__/capabilityShowcase.test.ts
@@ -1,0 +1,101 @@
+import { Notification } from '../src/store/notificationsSlice';
+import { PersonalizedEvent } from '../src/types/events';
+import { buildCapabilityShowcaseSummary } from '../src/utils/capabilityShowcase';
+
+function makeEvent(
+  overrides: Partial<PersonalizedEvent> = {},
+): PersonalizedEvent {
+  return {
+    clusterId: 'c1',
+    events: [],
+    primaryTicker: '7203',
+    allTickers: ['7203'],
+    title: 'テストイベント',
+    impact: '中',
+    eventType: '決算発表',
+    publishedAt: '2026-04-26T09:00:00.000Z',
+    sources: ['EDINET'],
+    relevanceScore: 80,
+    personalImpact: '中',
+    scoreReason: 'test',
+    ...overrides,
+  };
+}
+
+function makeNotification(overrides: Partial<Notification> = {}): Notification {
+  return {
+    id: 'n1',
+    ticker: '7203',
+    message: 'テスト通知',
+    importance: '中',
+    timestamp: '2026-04-26T09:05:00.000Z',
+    read: false,
+    ...overrides,
+  };
+}
+
+describe('buildCapabilityShowcaseSummary', () => {
+  test('空データ時は待機メッセージを返す', () => {
+    const summary = buildCapabilityShowcaseSummary([], []);
+
+    expect(summary.topTicker).toBe('N/A');
+    expect(summary.dominantImpact).toBe('なし');
+    expect(summary.eventCount).toBe(0);
+    expect(summary.alertMode).toBe('QUIET');
+    expect(summary.confidenceScore).toBe(0);
+  });
+
+  test('イベントからtop tickerとインパクト分布を計算する', () => {
+    const events = [
+      makeEvent({ primaryTicker: '7203', personalImpact: '中' }),
+      makeEvent({
+        clusterId: 'c2',
+        primaryTicker: '6758',
+        personalImpact: '強',
+      }),
+      makeEvent({
+        clusterId: 'c3',
+        primaryTicker: '6758',
+        personalImpact: '弱',
+      }),
+    ];
+
+    const summary = buildCapabilityShowcaseSummary(events, [
+      makeNotification(),
+      makeNotification({ id: 'n2', read: true }),
+    ]);
+
+    expect(summary.topTicker).toBe('6758');
+    expect(summary.dominantImpact).toBe('強');
+    expect(summary.impactBreakdown).toEqual({ strong: 1, medium: 1, weak: 1 });
+    expect(summary.unreadRate).toBe(50);
+  });
+
+  test('直近イベントが多い場合はIMMEDIATEモードになる', () => {
+    const now = new Date('2026-04-26T10:00:00.000Z');
+    const events = [
+      makeEvent({
+        clusterId: 'a1',
+        personalImpact: '中',
+        publishedAt: '2026-04-26T09:20:00.000Z',
+      }),
+      makeEvent({
+        clusterId: 'a2',
+        personalImpact: '中',
+        publishedAt: '2026-04-26T09:10:00.000Z',
+      }),
+      makeEvent({
+        clusterId: 'a3',
+        personalImpact: '中',
+        publishedAt: '2026-04-26T09:00:00.000Z',
+      }),
+    ];
+
+    const summary = buildCapabilityShowcaseSummary(events, [], now);
+
+    expect(summary.recencyHotCount).toBe(3);
+    expect(summary.alertMode).toBe('IMMEDIATE');
+    expect(summary.confidenceScore).toBeGreaterThan(0);
+    expect(summary.evidencePoints).toHaveLength(3);
+  });
+});

--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -1,0 +1,23 @@
+# Implementation Plan: 即興デモ機能（能力ショーケースカード v2）
+
+## 目的
+前回のシンプル表示から一段進め、ホーム画面で「今どれだけ危険/注目か」を即断できる分析カードへ強化する。
+
+## スコープ（小PR 1本）
+1. **分析ロジック強化**
+   - 既存の top ticker / impact 分布に加えて以下を追加。
+     - confidence score（0-100）
+     - 直近3時間イベント件数（recency hot count）
+     - 通知未読率（unread rate）
+     - alert mode（IMMEDIATE / WATCH / QUIET）
+     - evidence points（根拠3行）
+2. **UI改善**
+   - Capability Showcase card に confidenceバー、alert mode、根拠リストを追加。
+3. **テスト拡充**
+   - 既存テストを拡張し、未読率と recency 起点のモード切替を検証。
+4. **検証**
+   - lint / 対象テストを実行して回帰なしを確認。
+
+## リスク
+- スコアはヒューリスティックであり絶対指標ではない。
+- recency 判定はクライアント時刻依存のため、将来的にはサーバ時刻同期が望ましい。

--- a/src/components/CapabilityShowcaseCard.tsx
+++ b/src/components/CapabilityShowcaseCard.tsx
@@ -1,0 +1,192 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { Notification } from '../store/notificationsSlice';
+import { PersonalizedEvent } from '../types/events';
+import { buildCapabilityShowcaseSummary } from '../utils/capabilityShowcase';
+
+interface CapabilityShowcaseCardProps {
+  events: PersonalizedEvent[];
+  notifications: Notification[];
+}
+
+function getAlertModeLabel(mode: 'IMMEDIATE' | 'WATCH' | 'QUIET'): string {
+  if (mode === 'IMMEDIATE') return '即時対応';
+  if (mode === 'WATCH') return '監視強化';
+  return '静穏運用';
+}
+
+export default function CapabilityShowcaseCard({
+  events,
+  notifications,
+}: CapabilityShowcaseCardProps) {
+  const summary = useMemo(
+    () => buildCapabilityShowcaseSummary(events, notifications),
+    [events, notifications],
+  );
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>⚡ Capability Showcase</Text>
+      <Text style={styles.headline}>{summary.headline}</Text>
+
+      <View style={styles.statsRow}>
+        <View style={styles.statBlock}>
+          <Text style={styles.statLabel}>Top Ticker</Text>
+          <Text style={styles.statValue}>{summary.topTicker}</Text>
+        </View>
+        <View style={styles.statBlock}>
+          <Text style={styles.statLabel}>Alert Mode</Text>
+          <Text style={styles.statValue}>
+            {getAlertModeLabel(summary.alertMode)}
+          </Text>
+        </View>
+      </View>
+
+      <View style={styles.scoreBlock}>
+        <Text style={styles.scoreTitle}>Signal Confidence</Text>
+        <Text style={styles.scoreValue}>{summary.confidenceScore}%</Text>
+        <View style={styles.progressTrack}>
+          <View
+            style={[
+              styles.progressFill,
+              { width: `${summary.confidenceScore}%` },
+              summary.confidenceScore >= 70
+                ? styles.fillHigh
+                : summary.confidenceScore >= 40
+                  ? styles.fillMedium
+                  : styles.fillLow,
+            ]}
+          />
+        </View>
+      </View>
+
+      <Text style={styles.meta}>
+        Events {summary.eventCount}件 / Notifications{' '}
+        {summary.notificationCount}件
+      </Text>
+      <Text style={styles.meta}>
+        強:{summary.impactBreakdown.strong} 中:{summary.impactBreakdown.medium}{' '}
+        弱:
+        {summary.impactBreakdown.weak} / 直近3h:{summary.recencyHotCount}件 /
+        未読:
+        {summary.unreadRate}%
+      </Text>
+
+      <View style={styles.evidenceBox}>
+        {summary.evidencePoints.map((item) => (
+          <Text key={item} style={styles.evidenceItem}>
+            • {item}
+          </Text>
+        ))}
+      </View>
+
+      <Text style={styles.suggestion}>{summary.suggestedAction}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#111827',
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#374151',
+    padding: 16,
+    marginBottom: 16,
+  },
+  title: {
+    color: '#93C5FD',
+    fontSize: 15,
+    fontWeight: '700',
+    marginBottom: 8,
+  },
+  headline: {
+    color: '#F9FAFB',
+    fontSize: 16,
+    fontWeight: '700',
+    lineHeight: 22,
+    marginBottom: 12,
+  },
+  statsRow: {
+    flexDirection: 'row',
+    gap: 10,
+    marginBottom: 10,
+  },
+  statBlock: {
+    backgroundColor: '#1F2937',
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    flex: 1,
+  },
+  statLabel: {
+    color: '#9CA3AF',
+    fontSize: 11,
+    marginBottom: 4,
+  },
+  statValue: {
+    color: '#E5E7EB',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  scoreBlock: {
+    backgroundColor: '#0B1220',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#1F2937',
+    padding: 10,
+    marginBottom: 10,
+  },
+  scoreTitle: {
+    color: '#9CA3AF',
+    fontSize: 12,
+    marginBottom: 4,
+  },
+  scoreValue: {
+    color: '#A5B4FC',
+    fontSize: 20,
+    fontWeight: '700',
+    marginBottom: 8,
+  },
+  progressTrack: {
+    height: 8,
+    borderRadius: 999,
+    backgroundColor: '#1F2937',
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+    borderRadius: 999,
+  },
+  fillHigh: {
+    backgroundColor: '#22C55E',
+  },
+  fillMedium: {
+    backgroundColor: '#F59E0B',
+  },
+  fillLow: {
+    backgroundColor: '#EF4444',
+  },
+  meta: {
+    color: '#D1D5DB',
+    fontSize: 12,
+    marginBottom: 6,
+  },
+  evidenceBox: {
+    marginTop: 2,
+    marginBottom: 8,
+    gap: 4,
+  },
+  evidenceItem: {
+    color: '#E5E7EB',
+    fontSize: 12,
+    lineHeight: 18,
+  },
+  suggestion: {
+    marginTop: 8,
+    color: '#C7D2FE',
+    fontSize: 13,
+    lineHeight: 19,
+  },
+});

--- a/src/utils/capabilityShowcase.ts
+++ b/src/utils/capabilityShowcase.ts
@@ -1,0 +1,155 @@
+import { Notification } from '../store/notificationsSlice';
+import { PersonalizedEvent } from '../types/events';
+
+export interface CapabilityShowcaseSummary {
+  headline: string;
+  topTicker: string;
+  eventCount: number;
+  notificationCount: number;
+  dominantImpact: '強' | '中' | '弱' | 'なし';
+  impactBreakdown: {
+    strong: number;
+    medium: number;
+    weak: number;
+  };
+  confidenceScore: number;
+  recencyHotCount: number;
+  unreadRate: number;
+  alertMode: 'IMMEDIATE' | 'WATCH' | 'QUIET';
+  evidencePoints: string[];
+  suggestedAction: string;
+}
+
+const impactPriority: Record<'強' | '中' | '弱', number> = {
+  強: 3,
+  中: 2,
+  弱: 1,
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function getRecencyHotCount(
+  events: PersonalizedEvent[],
+  now: Date,
+  windowMinutes: number,
+): number {
+  const windowMs = windowMinutes * 60 * 1000;
+
+  return events.filter((event) => {
+    const publishedAt = new Date(event.publishedAt).getTime();
+    return (
+      !Number.isNaN(publishedAt) && now.getTime() - publishedAt <= windowMs
+    );
+  }).length;
+}
+
+export function buildCapabilityShowcaseSummary(
+  events: PersonalizedEvent[],
+  notifications: Notification[],
+  now: Date = new Date(),
+): CapabilityShowcaseSummary {
+  if (events.length === 0 && notifications.length === 0) {
+    return {
+      headline: 'データ待機中: 監視を開始すると即時分析を表示します',
+      topTicker: 'N/A',
+      eventCount: 0,
+      notificationCount: 0,
+      dominantImpact: 'なし',
+      impactBreakdown: { strong: 0, medium: 0, weak: 0 },
+      confidenceScore: 0,
+      recencyHotCount: 0,
+      unreadRate: 0,
+      alertMode: 'QUIET',
+      evidencePoints: ['ウォッチリスト追加後にシグナルを算出します。'],
+      suggestedAction: 'ウォッチリストに銘柄を追加して観測を開始してください。',
+    };
+  }
+
+  const tickerCounts = new Map<string, number>();
+  const sourceDiversity = new Set<string>();
+
+  const impactBreakdown = events.reduce(
+    (acc, event) => {
+      tickerCounts.set(
+        event.primaryTicker,
+        (tickerCounts.get(event.primaryTicker) ?? 0) + 1,
+      );
+
+      event.sources.forEach((source) => sourceDiversity.add(source));
+
+      if (event.personalImpact === '強') acc.strong += 1;
+      if (event.personalImpact === '中') acc.medium += 1;
+      if (event.personalImpact === '弱') acc.weak += 1;
+
+      return acc;
+    },
+    { strong: 0, medium: 0, weak: 0 },
+  );
+
+  const topTicker = [...tickerCounts.entries()].sort(
+    (a, b) => b[1] - a[1],
+  )[0]?.[0];
+
+  const dominantImpact =
+    events
+      .map((event) => event.personalImpact)
+      .sort((a, b) => impactPriority[b] - impactPriority[a])[0] ?? 'なし';
+
+  const recencyHotCount = getRecencyHotCount(events, now, 180);
+  const unreadNotifications = notifications.filter((n) => !n.read).length;
+  const unreadRate =
+    notifications.length === 0
+      ? 0
+      : Math.round((unreadNotifications / notifications.length) * 100);
+
+  const confidenceRaw =
+    events.length * 8 +
+    impactBreakdown.strong * 12 +
+    sourceDiversity.size * 9 +
+    recencyHotCount * 6;
+  const confidenceScore = clamp(confidenceRaw, 0, 100);
+
+  const alertMode: CapabilityShowcaseSummary['alertMode'] =
+    dominantImpact === '強' || recencyHotCount >= 3
+      ? 'IMMEDIATE'
+      : dominantImpact === '中' || unreadRate >= 60
+        ? 'WATCH'
+        : 'QUIET';
+
+  const headline =
+    alertMode === 'IMMEDIATE'
+      ? '高優先シグナル検知: すぐ確認すべき局面です'
+      : alertMode === 'WATCH'
+        ? '監視強化モード: 追加情報で判断精度を上げる段階です'
+        : '静穏モード: 重要イベント発生まで低ノイズで運用可能です';
+
+  const suggestedAction =
+    alertMode === 'IMMEDIATE'
+      ? '一次ソース確認→該当銘柄のアラート優先度を高へ。次報が出るまで15分間隔で再評価してください。'
+      : alertMode === 'WATCH'
+        ? '中重要度イベントをウォッチし、フォローアップ通知をONにして変化率を追跡してください。'
+        : '現設定を維持し、強インパクト出現時のみ即時通知する運用が効率的です。';
+
+  const evidencePoints = [
+    `Top ticker: ${topTicker ?? 'N/A'}（${tickerCounts.get(topTicker ?? '') ?? 0}件）`,
+    `重要度分布: 強${impactBreakdown.strong} / 中${impactBreakdown.medium} / 弱${impactBreakdown.weak}`,
+    `直近3時間の新規イベント: ${recencyHotCount}件 / 通知未読率: ${unreadRate}%`,
+  ];
+
+  return {
+    headline,
+    topTicker: topTicker ?? 'N/A',
+    eventCount: events.length,
+    notificationCount: notifications.length,
+    dominantImpact,
+    impactBreakdown,
+    confidenceScore,
+    recencyHotCount,
+    unreadRate,
+    alertMode,
+    evidencePoints,
+    suggestedAction,
+  };
+}


### PR DESCRIPTION
### Motivation
- Surface a compact, immediate-analysis card on the home screen to help users judge current signal priority at-a-glance. 
- Provide richer heuristics (confidence score, recency hot count, unread rate, alert mode and evidence points) to improve situational awareness. 
- Ship a small, test-covered iteration of the feature so it can be validated and iterated independently.

### Description
- Introduces a new UI component `CapabilityShowcaseCard` in `src/components/CapabilityShowcaseCard.tsx` that renders headline, top ticker, alert mode, a confidence progress bar, meta stats and evidence lines. 
- Adds `buildCapabilityShowcaseSummary` in `src/utils/capabilityShowcase.ts`, which computes the summary payload (confidenceScore, recencyHotCount, unreadRate, alertMode, evidencePoints, etc.) from events and notifications. 
- Integrates the card into the home screen by importing and rendering it in `App.tsx` with the filtered events and notifications, and includes a small refactor to the importance sorting keys. 
- Adds unit tests in `__tests__/capabilityShowcase.test.ts` that exercise empty-data, impact distribution, and recency-driven alert mode behavior, and adds `implementation_plan.md` describing scope and risks.

### Testing
- Added unit tests in `__tests__/capabilityShowcase.test.ts` that validate `buildCapabilityShowcaseSummary` for empty data, impact/ticker aggregation, and recency-driven IMMEDIATE mode. 
- Ran the test suite (`yarn test` / `npm test`) and the new unit tests passed locally. 
- No regression in existing UI code observed from this change set during the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede685bc9c832aa4a02642afcc1c45)